### PR TITLE
Template search and data files generation changes

### DIFF
--- a/FixtureController.php
+++ b/FixtureController.php
@@ -366,7 +366,9 @@ class FixtureController extends \yii\console\controllers\FixtureController
         $foundTemplates = [];
 
         foreach ($files as $fileName) {
-            $foundTemplates[] = basename($fileName, '.php');
+            $relativeName = str_replace(Yii::getAlias($this->templatePath) . '/', "", $fileName);   // strip templatePath from current template's full path
+            $relativeName = str_replace(".php", "", $relativeName);                                 // strip extension
+            $foundTemplates[] = $relativeName;
         }
 
         return $foundTemplates;
@@ -446,7 +448,12 @@ class FixtureController extends \yii\console\controllers\FixtureController
 
         $content = $this->exportFixtures($fixtures);
 
-        file_put_contents($fixtureDataPath . '/'. $templateName . '.php', $content);
+        $dataFile = $fixtureDataPath . '/'. $templateName . '.php'; // data file full path
+        $dataFileDir = dirname($dataFile);                          // data file directory
+        if(!file_exists($dataFileDir)) {                            // if dir doesn't exist -
+            FileHelper::createDirectory($dataFileDir);              // create it
+        }
+        file_put_contents($dataFile, $content);
     }
 
     /**

--- a/FixtureController.php
+++ b/FixtureController.php
@@ -367,7 +367,7 @@ class FixtureController extends \yii\console\controllers\FixtureController
 
         foreach ($files as $fileName) {
             $relativeName = str_replace(Yii::getAlias($this->templatePath) . '/', "", $fileName);   // strip templatePath from current template's full path
-            $relativeName = str_replace(".php", "", $relativeName);                                 // strip extension
+            $relativeName = dirname($relativeName) . '/' . basename($relativeName,'.php');          // strip extension
             $foundTemplates[] = $relativeName;
         }
 


### PR DESCRIPTION
Template search and data files generation changes: relative path usage instead basename for templates and data tree structure support

| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | yes
| Breaks BC?    | no
| Tests pass?   | -