### PR TITLE
Using with Yii2 Advanced Template

### DIFF
--- a/docs/guide/basic-usage.md
+++ b/docs/guide/basic-usage.md
@@ -136,10 +136,10 @@ You can use it by adding it to the `$providers` property of the current command.
 ```
 
 
-Yii2 Advanced Template
-----------------------
+Yii 2 Advanced Template
+-----------------------
  
-When you want to run faker in the Yii2 advanced template, you need to specify your template and fixtureData path as @tests doesn't exist. For example if you want to setup common fixtures, use the following config in console/config/main.php:
+If you want to run faker in the Yii 2 advanced template, you need to set `templatePath` and `fixtureDataPath`. For example if you want to setup common fixtures, use the following config in `console/config/main.php`:
 
 ```php
 'controllerMap' => [

--- a/docs/guide/basic-usage.md
+++ b/docs/guide/basic-usage.md
@@ -134,3 +134,19 @@ You can use it by adding it to the `$providers` property of the current command.
     ],
 ]
 ```
+
+
+Yii2 Advanced Template
+----------------------
+ 
+When you want to run faker in the Yii2 advanced template, you need to specify your template and fixtureData path as @tests doesn't exist. For example if you want to setup common fixtures, use the following config in console/config/main.php:
+
+```php
+'controllerMap' => [
+    'fixture' => [
+        'class' => 'yii\faker\FixtureController',
+        'templatePath' => '@common/tests/templates/fixtures',
+        'fixtureDataPath' => '@common/tests/fixtures/data',
+    ],
+]
+```


### PR DESCRIPTION
When using Yii2-faker with Yii2 Advanced Template, it will fail with "The template path "@tests/unit/templates/fixtures" does not exist". Added information on setting the advanced template specific paths.

| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | 