### PR TITLE
Use Rector to generate `@property` tags

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,3 +6,4 @@
 /tests              export-ignore
 /docs               export-ignore
 /Makefile           export-ignore
+/rector.php         export-ignore

--- a/.github/workflows/rector.yml
+++ b/.github/workflows/rector.yml
@@ -1,0 +1,28 @@
+name: rector
+
+permissions:
+  contents: read
+
+on:
+  pull_request: &ignore-paths
+    paths-ignore:
+      - 'docs/**'
+      - '.github/CONTRIBUTING.md'
+      - '.github/FUNDING.yml'
+      - '.github/SECURITY.md'
+      - 'README.md'
+      - 'CHANGELOG.md'
+      - 'LICENSE.md'
+      - '.gitignore'
+      - '.gitattributes'
+      - '.editorconfig'
+      - 'docker-compose.yml'
+      - 'Makefile'
+
+  push: *ignore-paths
+
+jobs:
+  rector:
+    uses: yiisoft/yii2-actions/.github/workflows/rector.yml@6f8dc7a0de4cbcc0fffb6a20881f32bba0e13f44 # master
+    with:
+      php-version: '["8.5"]'

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,9 @@
         "phpunit/phpunit": "^9.6",
         "phpstan/phpstan": "^2.1",
         "phpstan/phpstan-phpunit": "^2.0",
-        "yiisoft/yii2-coding-standards": "^3.0"
+        "yiisoft/yii2-coding-standards": "^3.0",
+        "rector/rector": "^2.6",
+        "mspirkov/yii2-rector": "^0.1"
     },
     "autoload": {
         "psr-4": {
@@ -48,5 +50,12 @@
         "allow-plugins": {
             "yiisoft/yii2-composer": true
         }
+    },
+    "scripts": {
+        "cs": "./vendor/bin/phpcs",
+        "cs-fix": "./vendor/bin/phpcbf",
+        "static": "./vendor/bin/phpstan --memory-limit=-1",
+        "tests": "./vendor/bin/phpunit",
+        "rector": "./vendor/bin/rector"
     }
 }

--- a/rector.php
+++ b/rector.php
@@ -1,0 +1,15 @@
+<?php
+
+use MSpirkov\Yii2\Rector\Rules\AddPropertyTagsRector;
+use MSpirkov\Yii2\Rector\Rules\RemoveRedundantPropertyTagsRector;
+use Rector\Config\RectorConfig;
+
+return RectorConfig::configure()
+    ->withPaths([
+        __DIR__ . '/src',
+        __DIR__ . '/tests',
+    ])
+    ->withRules([
+        AddPropertyTagsRector::class,
+        RemoveRedundantPropertyTagsRector::class,
+    ]);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | comma-separated list of tickets # fixed by the PR, if any
